### PR TITLE
Memcpy size optimized enhancement

### DIFF
--- a/newlib/libc/machine/riscv/memcpy-asm.S
+++ b/newlib/libc/machine/riscv/memcpy-asm.S
@@ -14,14 +14,14 @@
 .global memcpy
 .type	memcpy, @function
 memcpy:
-  mv t1, a0
+  mv a3, a0
   beqz a2, 2f
 
 1:
-  lbu t2, 0(a1)
-  sb t2, 0(t1)
+  lbu a4, 0(a1)
+  sb a4, 0(a3)
   add   a2, a2, -1
-  add   t1, t1, 1
+  add   a3, a3, 1
   add   a1, a1, 1
   bnez a2, 1b
 

--- a/newlib/libc/machine/riscv/memcpy-asm.S
+++ b/newlib/libc/machine/riscv/memcpy-asm.S
@@ -18,7 +18,7 @@ memcpy:
   beqz a2, 2f
 
 1:
-  lb t2, 0(a1)
+  lbu t2, 0(a1)
   sb t2, 0(t1)
   add   a2, a2, -1
   add   t1, t1, 1


### PR DESCRIPTION
This optimizes the memcpy version used when PREFER_SIZE_OVER_SPEED is specified. This introduces two changes:

1. Use lbu instead of lb to avoid unnecessary sign extension in hardware
2. Use compressed registers exclusively to make sure all instructions are compressed. When C and ZCB extensions are available, this is the generated code:

```asm
0001175c <memcpy>:
   1175c:	86aa                	mv	a3,a0
   1175e: 	c619                	beqz	a2,1176c <memcpy+0x10>
   11760: 	8198                	lbu	a4,0(a1)
   11762:	8a98                	sb	a4,0(a3)
   11764:	167d                	addi	a2,a2,-1
   11766: 	0685                	addi	a3,a3,1
   11768: 	0585                	addi	a1,a1,1
   1176a: 	fa7d                	bnez	a2,11760 <memcpy+0x4>
   1176c:       8082                	ret
```