### PR TITLE
setjmp optimization

### DIFF
--- a/newlib/libc/machine/riscv/setjmp.S
+++ b/newlib/libc/machine/riscv/setjmp.S
@@ -16,21 +16,33 @@
   .type   setjmp, @function
 setjmp:
 	REG_S ra,  0*SZREG(a0)
-	REG_S s0,  1*SZREG(a0)
-	REG_S s1,  2*SZREG(a0)
+  #if __riscv_xlen == 32 && (__riscv_zilsd || __riscv_zclsd)
+    sd    s0,  1*SZREG(a0)
+  #else
+	  REG_S s0,  1*SZREG(a0)
+	  REG_S s1,  2*SZREG(a0)
+  #endif
 
 #ifndef __riscv_32e
-	REG_S s2,  3*SZREG(a0)
-	REG_S s3,  4*SZREG(a0)
-	REG_S s4,  5*SZREG(a0)
-	REG_S s5,  6*SZREG(a0)
-	REG_S s6,  7*SZREG(a0)
-	REG_S s7,  8*SZREG(a0)
-	REG_S s8,  9*SZREG(a0)
-	REG_S s9, 10*SZREG(a0)
-	REG_S s10,11*SZREG(a0)
-	REG_S s11,12*SZREG(a0)
-	REG_S sp, 13*SZREG(a0)
+  #if __riscv_xlen == 32 && (__riscv_zilsd || __riscv_zclsd)
+    sd    s2,  3*SZREG(a0)
+    sd    s4,  5*SZREG(a0)
+    sd    s6,  7*SZREG(a0)
+    sd    s8,  9*SZREG(a0)
+    sd    s10,11*SZREG(a0)
+  #else
+	  REG_S s2,  3*SZREG(a0)
+	  REG_S s3,  4*SZREG(a0)
+	  REG_S s4,  5*SZREG(a0)
+	  REG_S s5,  6*SZREG(a0)
+	  REG_S s6,  7*SZREG(a0)
+	  REG_S s7,  8*SZREG(a0)
+	  REG_S s8,  9*SZREG(a0)
+	  REG_S s9, 10*SZREG(a0)
+	  REG_S s10,11*SZREG(a0)
+	  REG_S s11,12*SZREG(a0)
+  #endif
+  REG_S sp, 13*SZREG(a0)
 #else
 	REG_S sp, 3*SZREG(a0)
 #endif
@@ -59,19 +71,31 @@ setjmp:
   .type   longjmp, @function
 longjmp:
 	REG_L ra,  0*SZREG(a0)
-	REG_L s0,  1*SZREG(a0)
-	REG_L s1,  2*SZREG(a0)
+  #if __riscv_xlen == 32 && (__riscv_zilsd || __riscv_zclsd)
+    ld s0, 1*SZREG(a0)
+  #else
+    REG_L s0,  1*SZREG(a0)
+    REG_L s1,  2*SZREG(a0)
+  #endif
 #ifndef __riscv_32e
-	REG_L s2,  3*SZREG(a0)
-	REG_L s3,  4*SZREG(a0)
-	REG_L s4,  5*SZREG(a0)
-	REG_L s5,  6*SZREG(a0)
-	REG_L s6,  7*SZREG(a0)
-	REG_L s7,  8*SZREG(a0)
-	REG_L s8,  9*SZREG(a0)
-	REG_L s9, 10*SZREG(a0)
-	REG_L s10,11*SZREG(a0)
-	REG_L s11,12*SZREG(a0)
+  #if __riscv_xlen == 32 && (__riscv_zilsd || __riscv_zclsd)
+    ld    s2,  3*SZREG(a0)
+    ld    s4,  5*SZREG(a0)
+    ld    s6,  7*SZREG(a0)
+    ld    s8,  9*SZREG(a0)
+    ld    s10,11*SZREG(a0)
+  #else
+	  REG_L s2,  3*SZREG(a0)
+	  REG_L s3,  4*SZREG(a0)
+	  REG_L s4,  5*SZREG(a0)
+	  REG_L s5,  6*SZREG(a0)
+	  REG_L s6,  7*SZREG(a0)
+	  REG_L s7,  8*SZREG(a0)
+	  REG_L s8,  9*SZREG(a0)
+	  REG_L s9, 10*SZREG(a0)
+	  REG_L s10,11*SZREG(a0)
+	  REG_L s11,12*SZREG(a0)
+  #endif
 	REG_L sp, 13*SZREG(a0)
 #else
 	REG_L sp, 3*SZREG(a0)


### PR DESCRIPTION
There wasn't much here to optimize, I just made use of the `Zilsd` extension to reduce the code size. The entire code is basically register load/store instructions, no logic involved as such. Eric had suggested to have a look at the `Zcmp` extension, but since we are using a buffer to save the register state and not the stack itself, I don't think it'd be useful.

I got a code size reduction of `40b` when the target supports `Zilsd` extension.