### PR TITLE
memchr and memrchr

### DIFF
--- a/newlib/libc/machine/riscv/Makefile.inc
+++ b/newlib/libc/machine/riscv/Makefile.inc
@@ -1,3 +1,3 @@
 libc_a_SOURCES += \
 	%D%/memmove.S %D%/memmove-stub.c %D%/memset.S %D%/memcpy-asm.S %D%/memcpy.c %D%/strlen.c \
-	%D%/strcpy.c %D%/stpcpy.c %D%/strcmp.S %D%/setjmp.S %D%/ieeefp.c %D%/ffs.c
+	%D%/strcpy.c %D%/stpcpy.c %D%/strcmp.S %D%/memchr.c %D%/memrchr.c %D%/setjmp.S %D%/ieeefp.c %D%/ffs.c

--- a/newlib/libc/machine/riscv/memchr.c
+++ b/newlib/libc/machine/riscv/memchr.c
@@ -1,0 +1,99 @@
+/*
+FUNCTION
+	<<memchr>>---find character in memory
+
+INDEX
+	memchr
+
+SYNOPSIS
+	#include <string.h>
+	void *memchr(const void *<[src]>, int <[c]>, size_t <[length]>);
+
+DESCRIPTION
+	This function searches memory starting at <<*<[src]>>> for the
+	character <[c]>.  The search only ends with the first
+	occurrence of <[c]>, or after <[length]> characters; in
+	particular, <<NUL>> does not terminate the search.
+
+RETURNS
+	If the character <[c]> is found within <[length]> characters
+	of <<*<[src]>>>, a pointer to the character is returned. If
+	<[c]> is not found, then <<NULL>> is returned.
+
+PORTABILITY
+<<memchr>> is ANSI C.
+
+<<memchr>> requires no supporting OS subroutines.
+
+QUICKREF
+	memchr ansi pure
+*/
+
+#include <_ansi.h>
+#include <string.h>
+#include <limits.h>
+#include "../../string/local.h"
+
+void *
+memchr (const void *src_void,
+	int c,
+	size_t length)
+{
+  const unsigned char *src = (const unsigned char *) src_void;
+  unsigned char d = c;
+
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+  unsigned long *asrc;
+  unsigned long  mask;
+  unsigned int i;
+
+  while (UNALIGNED_X(src))
+    {
+      if (!length--)
+        return NULL;
+      if (*src == d)
+        return (void *) src;
+      src++;
+    }
+
+  if (!TOO_SMALL_LITTLE_BLOCK(length))
+    {
+      /* If we get this far, we know that length is large and src is
+         word-aligned. */
+      /* The fast code reads the source one word at a time and only
+         performs the bytewise search on word-sized segments if they
+         contain the search character, which is detected by XORing
+         the word-sized segment with a word-sized block of the search
+         character and then detecting for the presence of NUL in the
+         result.  */
+      asrc = (unsigned long *) src;
+      mask = d << 8 | d;
+      mask = mask << 16 | mask;
+      for (i = 32; i < sizeof(mask) * 8; i <<= 1)
+        mask = (mask << i) | mask;
+
+      while (!TOO_SMALL_LITTLE_BLOCK(length))
+        {
+          if (DETECT_CHAR(*asrc, mask))
+            break;
+          length -= LITTLE_BLOCK_SIZE;
+          asrc++;
+        }
+
+      /* If there are fewer than LITTLE_BLOCK_SIZE characters left,
+         then we resort to the bytewise loop.  */
+
+      src = (unsigned char *) asrc;
+    }
+
+#endif /* not PREFER_SIZE_OVER_SPEED */
+
+  while (length--)
+    {
+      if (*src == d)
+        return (void *) src;
+      src++;
+    }
+
+  return NULL;
+}

--- a/newlib/libc/machine/riscv/memchr.c
+++ b/newlib/libc/machine/riscv/memchr.c
@@ -29,10 +29,15 @@ QUICKREF
 	memchr ansi pure
 */
 
-#include <_ansi.h>
-#include <string.h>
-#include <limits.h>
-#include "../../string/local.h"
+#include <sys/asm.h>
+#include <stddef.h>
+#include "rv_string.h"
+
+#if __riscv_zilsd
+#undef  SZREG
+#define SZREG           8
+#endif
+
 
 void *
 memchr (const void *src_void,
@@ -43,47 +48,101 @@ memchr (const void *src_void,
   unsigned char d = c;
 
 #if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
-  unsigned long *asrc;
-  unsigned long  mask;
-  unsigned int i;
+  size_t align = (uintptr_t) src & (SZREG - 1);
 
-  while (UNALIGNED_X(src))
+  if (align)
     {
-      if (!length--)
-        return NULL;
-      if (*src == d)
-        return (void *) src;
-      src++;
-    }
+      align = SZREG - align;
 
-  if (!TOO_SMALL_LITTLE_BLOCK(length))
-    {
-      /* If we get this far, we know that length is large and src is
-         word-aligned. */
-      /* The fast code reads the source one word at a time and only
-         performs the bytewise search on word-sized segments if they
-         contain the search character, which is detected by XORing
-         the word-sized segment with a word-sized block of the search
-         character and then detecting for the presence of NUL in the
-         result.  */
-      asrc = (unsigned long *) src;
-      mask = d << 8 | d;
-      mask = mask << 16 | mask;
-      for (i = 32; i < sizeof(mask) * 8; i <<= 1)
-        mask = (mask << i) | mask;
+      if (length < align) align = length;
 
-      while (!TOO_SMALL_LITTLE_BLOCK(length))
+      switch (align)
         {
-          if (DETECT_CHAR(*asrc, mask))
-            break;
-          length -= LITTLE_BLOCK_SIZE;
-          asrc++;
+#if SZREG == 8
+          case 7:
+            if (*src++ == d) return (void *) (src - 1);
+          case 6:
+            if (*src++ == d) return (void *) (src - 1);
+          case 5:
+            if (*src++ == d) return (void *) (src - 1);
+          case 4:
+            if (*src++ == d) return (void *) (src - 1);
+#endif /* SZREG == 8 */
+          case 3:
+            if (*src++ == d) return (void *) (src - 1);
+          case 2:
+            if (*src++ == d) return (void *) (src - 1);
+          case 1:
+            if (*src++ == d) return (void *) (src - 1);
         }
 
-      /* If there are fewer than LITTLE_BLOCK_SIZE characters left,
-         then we resort to the bytewise loop.  */
+      length -= align;
+    }
 
-      src = (unsigned char *) asrc;
+  const unsigned char *end_addr = src + (length & ~(SZREG - 1));
+
+  if (src < end_addr)
+    {
+      uintxlen_t mask = __libc_splat_byte(d);
+      uintlslen_t val;
+
+      do
+        {
+#if __riscv_zilsd
+          asm volatile ("ld %0, 0(%1)"
+                        : "=R" (val)
+                        : "r" (src)
+          );
+#else /* not riscv_zilsd */
+          val = *(uintxlen_t*) src;
+#endif /* __riscv_zilsd */
+          uintxlen_t word1 = val ^ mask;
+
+          if (__libc_detect_null(word1))
+            {
+#if __riscv_zbb
+              word1 = ~__LIBC_RISCV_ZBB_ORC_B(word1);
+              word1 = __LIBC_RISCV_ZBB_CNT_Z(word1);
+
+              return (void *) (src + (word1 >> 3));
+#else /* not __riscv_zbb */
+              if (*src++ == d) return (void *) (src - 1);
+              if (*src++ == d) return (void *) (src - 1);
+              if (*src++ == d) return (void *) (src - 1);
+#if __riscv_xlen == 64
+              if (*src++ == d) return (void *) (src - 1);
+              if (*src++ == d) return (void *) (src - 1);
+              if (*src++ == d) return (void *) (src - 1);
+              if (*src++ == d) return (void *) (src - 1);
+#endif /* __riscv_xlen == 64 */
+              return (void *) src;
+#endif /* __riscv_zbb */
+            }
+#if __riscv_zilsd
+          uintxlen_t word2 = (val >> 32);
+          word2 ^= mask;
+
+          if (__libc_detect_null(word2))
+            {
+              src += SZREG / 2;
+#if __riscv_zbb
+              word2 = ~__LIBC_RISCV_ZBB_ORC_B(word2);
+              word2 = __LIBC_RISCV_ZBB_CNT_Z(word2);
+
+              return (void *) (src + (word2 >> 3));
+#else /* not __riscv_zbb */
+              if (*src++ == d) return (void *) (src - 1);
+              if (*src++ == d) return (void *) (src - 1);
+              if (*src++ == d) return (void *) (src - 1);
+              return (void *) src;
+#endif /* __riscv_zbb */
+            }
+#endif /* __riscv_zilsd */
+
+          src += SZREG;
+        } while (src < end_addr);
+
+      length &= SZREG - 1;
     }
 
 #endif /* not PREFER_SIZE_OVER_SPEED */

--- a/newlib/libc/machine/riscv/memrchr.c
+++ b/newlib/libc/machine/riscv/memrchr.c
@@ -1,0 +1,99 @@
+/*
+FUNCTION
+	<<memrchr>>---reverse search for character in memory
+
+INDEX
+	memrchr
+
+SYNOPSIS
+	#include <string.h>
+	void *memrchr(const void *<[src]>, int <[c]>, size_t <[length]>);
+
+DESCRIPTION
+	This function searches memory starting at <[length]> bytes
+	beyond <<*<[src]>>> backwards for the character <[c]>.
+	The search only ends with the first occurrence of <[c]>; in
+	particular, <<NUL>> does not terminate the search.
+
+RETURNS
+	If the character <[c]> is found within <[length]> characters
+	of <<*<[src]>>>, a pointer to the character is returned. If
+	<[c]> is not found, then <<NULL>> is returned.
+
+PORTABILITY
+<<memrchr>> is a GNU extension.
+
+<<memrchr>> requires no supporting OS subroutines.
+
+QUICKREF
+	memrchr
+*/
+
+#include <_ansi.h>
+#include <string.h>
+#include <limits.h>
+#include "../../string/local.h"
+
+void *
+memrchr (const void *src_void,
+	int c,
+	size_t length)
+{
+  const unsigned char *src = (const unsigned char *) src_void + length - 1;
+  unsigned char d = c;
+
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+  unsigned long *asrc;
+  unsigned long  mask;
+  unsigned int i;
+
+  while (UNALIGNED_X(src))
+    {
+      if (!length--)
+        return NULL;
+      if (*src == d)
+        return (void *) src;
+      src--;
+    }
+
+  if (!TOO_SMALL_LITTLE_BLOCK(length))
+    {
+      /* If we get this far, we know that length is large and src is
+         word-aligned. */
+      /* The fast code reads the source one word at a time and only
+         performs the bytewise search on word-sized segments if they
+         contain the search character, which is detected by XORing
+         the word-sized segment with a word-sized block of the search
+         character and then detecting for the presence of NUL in the
+         result.  */
+      asrc = (unsigned long *) (src - LITTLE_BLOCK_SIZE + 1);
+      mask = d << 8 | d;
+      mask = mask << 16 | mask;
+      for (i = 32; i < sizeof(mask) * 8; i <<= 1)
+        mask = (mask << i) | mask;
+
+      while (!TOO_SMALL_LITTLE_BLOCK(length))
+        {
+          if (DETECT_CHAR(*asrc, mask))
+            break;
+          length -= LITTLE_BLOCK_SIZE;
+          asrc--;
+        }
+
+      /* If there are fewer than LITTLE_BLOCK_SIZE characters left,
+         then we resort to the bytewise loop.  */
+
+      src = (unsigned char *) asrc + LITTLE_BLOCK_SIZE - 1;
+    }
+
+#endif /* not PREFER_SIZE_OVER_SPEED */
+
+  while (length--)
+    {
+      if (*src == d)
+        return (void *) src;
+      src--;
+    }
+
+  return NULL;
+}

--- a/newlib/libc/machine/riscv/memrchr.c
+++ b/newlib/libc/machine/riscv/memrchr.c
@@ -29,61 +29,141 @@ QUICKREF
 	memrchr
 */
 
-#include <_ansi.h>
-#include <string.h>
-#include <limits.h>
-#include "../../string/local.h"
+#include <sys/asm.h>
+#include <stddef.h>
+#include "rv_string.h"
+
+#if __riscv_zilsd
+#undef  SZREG
+#define SZREG           8
+
+// Offset is only 4 bytes for Zilsd/Zclsd since each register is 32 bits
+#define OFFSET          4
+#else
+#define OFFSET          SZREG
+#endif
+
 
 void *
 memrchr (const void *src_void,
 	int c,
 	size_t length)
 {
-  const unsigned char *src = (const unsigned char *) src_void + length - 1;
+  const unsigned char *src = (const unsigned char *) src_void;
   unsigned char d = c;
 
+  if (length) src += length - 1;
+
 #if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
-  unsigned long *asrc;
-  unsigned long  mask;
-  unsigned int i;
 
-  while (UNALIGNED_X(src))
+  /*
+    We add one to the address because even if an address is already aligned,
+    when loading words the bytes preceding this address are read, so check
+    the single byte.
+
+    If the address has all the least significant bits set equaling SZREG - 1,
+    and has a length of at least SZREG, we can read a word starting from
+    src & ~(SZREG - 1) because no alignment is actually required
+  */
+  size_t align = (uintptr_t) (src + 1) & (SZREG - 1);
+
+  if (align)
     {
-      if (!length--)
-        return NULL;
-      if (*src == d)
-        return (void *) src;
-      src--;
-    }
+      if (length < align) align = length;
 
-  if (!TOO_SMALL_LITTLE_BLOCK(length))
-    {
-      /* If we get this far, we know that length is large and src is
-         word-aligned. */
-      /* The fast code reads the source one word at a time and only
-         performs the bytewise search on word-sized segments if they
-         contain the search character, which is detected by XORing
-         the word-sized segment with a word-sized block of the search
-         character and then detecting for the presence of NUL in the
-         result.  */
-      asrc = (unsigned long *) (src - LITTLE_BLOCK_SIZE + 1);
-      mask = d << 8 | d;
-      mask = mask << 16 | mask;
-      for (i = 32; i < sizeof(mask) * 8; i <<= 1)
-        mask = (mask << i) | mask;
-
-      while (!TOO_SMALL_LITTLE_BLOCK(length))
+      switch (align)
         {
-          if (DETECT_CHAR(*asrc, mask))
-            break;
-          length -= LITTLE_BLOCK_SIZE;
-          asrc--;
+#if SZREG == 8
+          case 7:
+            if (*src-- == d) return (void *) (src + 1);
+          case 6:
+            if (*src-- == d) return (void *) (src + 1);
+          case 5:
+            if (*src-- == d) return (void *) (src + 1);
+          case 4:
+            if (*src-- == d) return (void *) (src + 1);
+#endif /* SZREG == 8 */
+          case 3:
+            if (*src-- == d) return (void *) (src + 1);
+          case 2:
+            if (*src-- == d) return (void *) (src + 1);
+          case 1:
+            if (*src-- == d) return (void *) (src + 1);
         }
 
-      /* If there are fewer than LITTLE_BLOCK_SIZE characters left,
-         then we resort to the bytewise loop.  */
+      length -= align;
+    }
 
-      src = (unsigned char *) asrc + LITTLE_BLOCK_SIZE - 1;
+  const unsigned char *end_addr = src - (length & ~(SZREG - 1));
+
+  if (src > end_addr)
+    {
+      src -= SZREG - 1;
+
+      uintxlen_t mask = __libc_splat_byte(d);
+      uintlslen_t val;
+
+      do
+        {
+#if __riscv_zilsd
+          asm volatile ("ld %0, 0(%1)"
+                        : "=R" (val)
+                        : "r" (src)
+          );
+#else /* not riscv_zilsd */
+          val = *(uintxlen_t*) src;
+#endif /* __riscv_zilsd */
+
+#if __riscv_zilsd
+          uintxlen_t word2 = val >> 32;
+          word2 ^= mask;
+
+          if (__libc_detect_null(word2))
+            {
+#if __riscv_zbb
+              src += OFFSET;
+              word2 = ~__LIBC_RISCV_ZBB_ORC_B(word2);
+              word2 = __LIBC_RISCV_ZBB_CNT_Z_REV(word2);
+
+              return (void *) (src + OFFSET - 1 - (word2 >> 3));
+#else /* not __riscv_zbb */
+              src += SZREG - 1;
+              if (*src-- == d) return (void *) (src + 1);
+              if (*src-- == d) return (void *) (src + 1);
+              if (*src-- == d) return (void *) (src + 1);
+              return (void *) src;
+#endif /* __riscv_zbb */
+            }
+#endif /* __riscv_zilsd */
+          uintxlen_t word1 = val ^ mask;
+
+          if (__libc_detect_null(word1))
+            {
+#if __riscv_zbb
+              word1 = ~__LIBC_RISCV_ZBB_ORC_B(word1);
+              word1 = __LIBC_RISCV_ZBB_CNT_Z_REV(word1);
+
+              return (void *) (src + OFFSET - 1 - (word1 >> 3));
+#else /* not __riscv_zbb */
+              src += OFFSET - 1;
+              if (*src-- == d) return (void *) (src + 1);
+              if (*src-- == d) return (void *) (src + 1);
+              if (*src-- == d) return (void *) (src + 1);
+#if __riscv_xlen == 64
+              if (*src-- == d) return (void *) (src + 1);
+              if (*src-- == d) return (void *) (src + 1);
+              if (*src-- == d) return (void *) (src + 1);
+              if (*src-- == d) return (void *) (src + 1);
+#endif /* __riscv_xlen == 64 */
+              return (void *) src;
+#endif /* __riscv_zbb */
+            }
+
+          src -= SZREG;
+        } while (src > end_addr);
+
+      length &= SZREG - 1;
+      src = end_addr;
     }
 
 #endif /* not PREFER_SIZE_OVER_SPEED */

--- a/newlib/libc/machine/riscv/xlenint.h
+++ b/newlib/libc/machine/riscv/xlenint.h
@@ -11,4 +11,11 @@ typedef uint32_t uintxlen_t;
 # error __riscv_xlen must equal 32 or 64
 #endif
 
+/* Load/Store length */
+#if __riscv_zilsd
+typedef uint64_t uintlslen_t;
+#else
+typedef uintxlen_t uintlslen_t;
+#endif
+
 #endif /* _XLENINT_H */


### PR DESCRIPTION
@christian-herber-nxp Here's my initial draft of `memchr()` and `memrchr()`. I implemented them in C, based off the Newlib stock versions.

`memchr()` is very similar to `strlen()`. `memrchr()` is different enough from `memchr()` that it warrants a separate source file. Sharing the code and adding add a boolean to distinguish between the two ended up making them hard to follow and slows down the performance of both. They're different enough to where it makes sense to separate them completely.

It'd be nice to add `Zilsd`/`Zclsd` to the `rv32` version, but I don't know how feasible this is. I thought I'd bring it up to you to get your initial thoughts before any attempts.